### PR TITLE
Add an additional 'strict' method of detecting whether pages are scanned.

### DIFF
--- a/src/main/java/fr/bnf/toolslab/ImageGraphicsEngine.java
+++ b/src/main/java/fr/bnf/toolslab/ImageGraphicsEngine.java
@@ -51,7 +51,12 @@ public class ImageGraphicsEngine extends PDFGraphicsStreamEngine { // TODO try P
 
   void run() throws IOException {
     PDPage page = getPage();
+    try {
     processPage(page);
+    } catch (NullPointerException e) {
+      // Occasionally PDFBox fails with an NPE. Ignore it and keep on going.
+      LOGGER.fine("Error processing page " + page.getCOSObject() + ": " + e.getMessage());
+    }
     PDResources res = page.getResources();
     if (res == null) {
       return;

--- a/src/main/java/fr/bnf/toolslab/PdfBoxScanDetector.java
+++ b/src/main/java/fr/bnf/toolslab/PdfBoxScanDetector.java
@@ -112,6 +112,9 @@ public class PdfBoxScanDetector extends AbstractScanDetector {
     AtomicInteger density = new AtomicInteger(0);
     // Enumerate the resources to avoid building a complete image
     PDResources resources = page.getResources();
+    // Since we're recursing over the list of images again, we need to clear 'seen objects' or we
+    // won't find nested images.
+    seenObjects.clear();
     recurseForImages(resources, dimImage -> {
       if (!DimensionInfo.EMPTY.equals(dimImage)) {
         density.set(findDensity(dimImage, dimPage, userUnit));

--- a/src/main/java/fr/bnf/toolslab/ScannedPdfApp.java
+++ b/src/main/java/fr/bnf/toolslab/ScannedPdfApp.java
@@ -29,6 +29,7 @@ public class ScannedPdfApp {
   public static void main(String[] args) throws IOException {
     boolean useAlternate = false;
     boolean useStream = false;
+    boolean useStrict = false;
     if (args.length < 1) {
       usage();
       return;
@@ -41,6 +42,10 @@ public class ScannedPdfApp {
       useStream = true;
       index++;
     }
+    else if ("-strict".equals(args[0])) {
+      useStrict = true;
+      index++;
+    }
 
     File inputFile = new File(args[index]);
     if (!inputFile.exists()) {
@@ -51,7 +56,8 @@ public class ScannedPdfApp {
 
     final AbstractScanDetector detector =
         useAlternate ? new AlternatePdfBoxScanDetector()
-            : (useStream ? new StreamPdfBoxScanDetector() : new PdfBoxScanDetector());
+            : (useStream ? new StreamPdfBoxScanDetector()
+                : (useStrict ? new StrictPdfBoxScanDetector() : new PdfBoxScanDetector()));
 
     if (inputFile.isFile()) {
       FileDescriptor fd = processFile(inputFile, detector);

--- a/src/main/java/fr/bnf/toolslab/StrictPdfBoxScanDetector.java
+++ b/src/main/java/fr/bnf/toolslab/StrictPdfBoxScanDetector.java
@@ -66,7 +66,6 @@ import org.apache.pdfbox.pdmodel.common.PDRectangle;
           fd.setScan(false);
           return;
         }
-        assert (pageDimensions.size() == imageDimensions.size());
 
         // Second heuristic: pick some pages and look if the image covers
         // all the page

--- a/src/main/java/fr/bnf/toolslab/StrictPdfBoxScanDetector.java
+++ b/src/main/java/fr/bnf/toolslab/StrictPdfBoxScanDetector.java
@@ -1,0 +1,156 @@
+package fr.bnf.toolslab;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Logger;
+import org.apache.pdfbox.cos.COSStream;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+
+  /**
+   * Copy of StreamPdfBoxScanDetector but with stricter rules, especially around avoiding marking
+   * children's books as scans.
+   */
+  public class StrictPdfBoxScanDetector extends AbstractScanDetector {
+    protected static final Logger LOGGER = Logger.getLogger(fr.bnf.toolslab.StrictPdfBoxScanDetector.class.getName());
+
+    FileDescriptor fd;
+    int nbPages;
+    int nbImages;
+    int nbImagesInPage;
+    List<DimensionInfo> pageDimensions;
+    List<DimensionInfo> imageDimensions;
+    private Map<COSStream, Integer> processedInlineImages = new HashMap<>();
+    private AtomicInteger inlineImageCounter = new AtomicInteger(0);
+
+    @Override
+    public void init(FileDescriptor fd) {
+      LOGGER.fine("Processing " + fd.getFile().getName());
+      this.fd = fd;
+      this.nbPages = 0;
+      this.nbImages = 0;
+      this.pageDimensions = new ArrayList<>();
+      this.imageDimensions = new ArrayList<>();
+      processedInlineImages = new HashMap<>();
+      inlineImageCounter = new AtomicInteger(0);
+    }
+
+    @Override
+    public void parse() throws IOException {
+      long beginTime = System.currentTimeMillis();
+      try (PDDocument document = PDDocument.load(fd.getFile())) {
+        this.nbPages = 0;
+        this.nbImages = 0;
+        fd.setValid(true);
+        fd.setNbPages(nbPages);
+        for (PDPage page : document.getPages()) {
+          this.nbPages++;
+          this.nbImages += parsePage(page, this.nbPages);
+        }
+        this.nbImages = inlineImageCounter.get();
+        fd.setNbPages(this.nbPages);
+        fd.setNbImages(this.nbImages);
+        LOGGER.fine("First pass in " + (System.currentTimeMillis() - beginTime));
+
+        // First heuristic: compare the number of pages and the number of
+        // images. Scanned documents often have more than one image per page,
+        // but they shouldn't have less.
+        if (this.nbPages > this.nbImages) {
+          LOGGER.fine("Find " + nbPages + " pages and " + nbImages + " images");
+          fd.setScan(false);
+          return;
+        }
+        assert (pageDimensions.size() == imageDimensions.size());
+
+        // Second heuristic: pick some pages and look if the image covers
+        // all the page
+        int nbSamples = Math.min(nbPages, MAX_SAMPLES);
+        List<Integer> pagesToTest = pickSamples(nbSamples, nbPages);
+
+        // Classify all the dpiFound (could be 0)
+        DpiCounter counter = new DpiCounter();
+
+        for (int pageNum : pagesToTest) {
+          DimensionInfo dimPage = pageDimensions.get(pageNum);
+          DimensionInfo dimImage = imageDimensions.get(pageNum);
+          LOGGER.fine("Page [" + pageNum + "] dimension " + dimImage);
+          // Heuristic three: if any of the sampled pages has no image, it's probably not a scan
+          if (dimImage == DimensionInfo.EMPTY) {
+            LOGGER.fine("Page [" + pageNum + "] has no image");
+            fd.setScan(false);
+            return;
+          }
+
+          int dpiFound = findDensity(dimImage, dimPage, 1.0f);
+          LOGGER.fine("Page [" + pageNum + "] density " + dpiFound);
+
+          if (dpiFound != 0) {
+            counter.increment(dpiFound);
+          }
+          else {
+            // Heuristic four: if any of the sampled pages has an image that doesn't cover the page,
+            // it's probably not a scan
+            LOGGER.fine("Page [" + pageNum + "] has an image that doesn't cover the page");
+            fd.setScan(false);
+            return;
+          }
+        }
+        // Find the most usual dpi
+        Entry<Integer, Integer> bestDpi = counter.getBest();
+        LOGGER.fine("Second pass in " + (System.currentTimeMillis() - beginTime));
+        if (bestDpi.getKey() == 0) {
+          LOGGER.info("No dpi found");
+          return;
+        }
+        // If more scanned pages than the threshold
+        LOGGER.fine("Most usual dpi is " + bestDpi.getKey() + " with "
+            + bestDpi.getValue().intValue() + " occurrences (" + counter.toString() + ")");
+        if (bestDpi.getValue().intValue() > nbSamples / THRESHOLD) {
+          fd.setScan(true);
+          fd.setResolution(bestDpi.getKey());
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+        fd.setValid(false);
+        throw e;
+      } finally {
+        fd.setTimeToProcess(System.currentTimeMillis() - beginTime);
+      }
+    }
+
+    protected int parsePage(PDPage page, int numPage) throws IOException {
+      nbImagesInPage = 0;
+      PDRectangle rect = page.getMediaBox(); // Found page dimension
+      // MediaBox specified in "default user space units", which is points
+      // (i.e. 72 dpi)
+      // float userUnit = page.getUserUnit(); // in multiples of 1/72 inch
+
+      DimensionInfo dimPage = new DimensionInfo((long) (rect.getWidth()), (long) (rect.getHeight()));
+      LOGGER.fine("Found page [" + numPage + "] with dimension " + dimPage.toString());
+      pageDimensions.add(dimPage);
+
+      try {
+        int initialNumber = inlineImageCounter.get();
+        ImageGraphicsEngine engine =
+            new ImageGraphicsEngine(page, processedInlineImages, inlineImageCounter);
+        engine.run();
+        nbImagesInPage = inlineImageCounter.get() - initialNumber;
+        if (nbImagesInPage == 0) {
+          imageDimensions.add(DimensionInfo.EMPTY);
+        } else {
+          imageDimensions.add(engine.getImageDimensions().get(0));
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+
+      }
+      return nbImagesInPage;
+    }
+  }
+


### PR DESCRIPTION
Using `StreamPdfBoxScanDetector` as a base, implement a variant 'strict' method of scan detection to try and decrease false-positives.

This improves on the original in two specific areas:
- Based on my testing, scanned PDFs can and will often have more images than pages
- Scans and Children's books share many similar attributes, and this method attempts to address this issue

One of the few ways to differentiate between a scan and a children's book is that children's books often have a colophon with publishing date, author, etc, and it's rare that 'native' children's books have large issues on the colophon page. On the other hand, scanned PDFs in the majority of circumstances should have a large image on every page. Therefore the 'strict' method considers a PDF to be native if it was any pages without large images.

As a personal note, I've extremely grateful for this project as it has formed the basis of my own work in PDF scan detection, so thank you.